### PR TITLE
build(deps): bump flake input `neovim-upstream`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665449194,
-        "narHash": "sha256-hYGjMZgOLdza1Z+/DfxLnqeTONNiwaeeuPab3mjq1pM=",
+        "lastModified": 1665459000,
+        "narHash": "sha256-4wpYkyTLyqiHHdGuVGdXaRVRzCQu04mzhiZBuMQW0Lw=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8f0b94b36d4d6687712ccfc525284f1fac58d2f6",
+        "rev": "d9a80b8e29182230693c9091ac397f96e7222fbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/8f0b94b36d4d6687712ccfc525284f1fac58d2f6` →
  `github:neovim/neovim/d9a80b8e29182230693c9091ac397f96e7222fbb`
  __([view changes](https://github.com/neovim/neovim/compare/8f0b94b36d4d6687712ccfc525284f1fac58d2f6...d9a80b8e29182230693c9091ac397f96e7222fbb))__