### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs_2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665459000,
-        "narHash": "sha256-4wpYkyTLyqiHHdGuVGdXaRVRzCQu04mzhiZBuMQW0Lw=",
+        "lastModified": 1665548414,
+        "narHash": "sha256-MZTZLz4DTGnehY6JCbJzx9EtvNuOPg/dOMvMKawaFBY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d9a80b8e29182230693c9091ac397f96e7222fbb",
+        "rev": "f175ca9f7cc29054b1c6fe1fd1076edd78af5684",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665259268,
-        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5924154f000e6306030300592f4282949b2db6c",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/d9a80b8e29182230693c9091ac397f96e7222fbb` →
  `github:neovim/neovim/f175ca9f7cc29054b1c6fe1fd1076edd78af5684`
  __([view changes](https://github.com/neovim/neovim/compare/d9a80b8e29182230693c9091ac397f96e7222fbb...f175ca9f7cc29054b1c6fe1fd1076edd78af5684))__
* __nixpkgs_2:__ 
  `github:nixos/nixpkgs/c5924154f000e6306030300592f4282949b2db6c` →
  `github:nixos/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1`
  __([view changes](https://github.com/nixos/nixpkgs/compare/c5924154f000e6306030300592f4282949b2db6c...34c5293a71ffdb2fe054eb5288adc1882c1eb0b1))__