### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`, `nixpkgs_2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,15 +36,17 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665548414,
-        "narHash": "sha256-MZTZLz4DTGnehY6JCbJzx9EtvNuOPg/dOMvMKawaFBY=",
+        "lastModified": 1665667128,
+        "narHash": "sha256-6/u4ngZrvStBzqvgSP+UjRSAC7mI2D35mU0oDXLbzbM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f175ca9f7cc29054b1c6fe1fd1076edd78af5684",
+        "rev": "eb123b565e201418dd135d2602dc20eea3cead39",
         "type": "github"
       },
       "original": {
@@ -56,27 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662019588,
-        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
+        "lastModified": 1665580254,
+        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
         "type": "github"
       },
       "original": {
@@ -91,7 +77,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "neovim-upstream": "neovim-upstream",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/f175ca9f7cc29054b1c6fe1fd1076edd78af5684` →
  `github:neovim/neovim/eb123b565e201418dd135d2602dc20eea3cead39`
  __([view changes](https://github.com/neovim/neovim/compare/f175ca9f7cc29054b1c6fe1fd1076edd78af5684...eb123b565e201418dd135d2602dc20eea3cead39))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/2da64a81275b68fdad38af669afeda43d401e94b` →
  `github:nixos/nixpkgs/f634d427b0224a5f531ea5aa10c3960ba6ec5f0f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/2da64a81275b68fdad38af669afeda43d401e94b...f634d427b0224a5f531ea5aa10c3960ba6ec5f0f))__

## Removed Inputs

* __nixpkgs_2:__ `github:nixos/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1`