### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665667128,
-        "narHash": "sha256-6/u4ngZrvStBzqvgSP+UjRSAC7mI2D35mU0oDXLbzbM=",
+        "lastModified": 1666150346,
+        "narHash": "sha256-RnQhovyu3t6WuruYHhzcm9bgs7CPsCFSaa01N84gp+I=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "eb123b565e201418dd135d2602dc20eea3cead39",
+        "rev": "96cf385a7f4ab29f6987c10b5c3625d99b22f6fc",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665580254,
-        "narHash": "sha256-hO61XPkp1Hphl4HGNzj1VvDH5URt7LI6LaY/385Eul4=",
+        "lastModified": 1666109165,
+        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f634d427b0224a5f531ea5aa10c3960ba6ec5f0f",
+        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/eb123b565e201418dd135d2602dc20eea3cead39` →
  `github:neovim/neovim/96cf385a7f4ab29f6987c10b5c3625d99b22f6fc`
  __([view changes](https://github.com/neovim/neovim/compare/eb123b565e201418dd135d2602dc20eea3cead39...96cf385a7f4ab29f6987c10b5c3625d99b22f6fc))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/f634d427b0224a5f531ea5aa10c3960ba6ec5f0f` →
  `github:nixos/nixpkgs/32096899af23d49010bd8cf6a91695888d9d9e73`
  __([view changes](https://github.com/nixos/nixpkgs/compare/f634d427b0224a5f531ea5aa10c3960ba6ec5f0f...32096899af23d49010bd8cf6a91695888d9d9e73))__