### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1666150346,
-        "narHash": "sha256-RnQhovyu3t6WuruYHhzcm9bgs7CPsCFSaa01N84gp+I=",
+        "lastModified": 1666766306,
+        "narHash": "sha256-ttI5NiFPTBSDlHIHn4fiE0KUk890OTAgPbFKi7YpF6Y=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "96cf385a7f4ab29f6987c10b5c3625d99b22f6fc",
+        "rev": "c00844aee4d9b607073ff123dfe2e872c9b84954",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666109165,
-        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/96cf385a7f4ab29f6987c10b5c3625d99b22f6fc` →
  `github:neovim/neovim/c00844aee4d9b607073ff123dfe2e872c9b84954`
  __([view changes](https://github.com/neovim/neovim/compare/96cf385a7f4ab29f6987c10b5c3625d99b22f6fc...c00844aee4d9b607073ff123dfe2e872c9b84954))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/32096899af23d49010bd8cf6a91695888d9d9e73` →
  `github:nixos/nixpkgs/f994293d1eb8812f032e8919e10a594567cf6ef7`
  __([view changes](https://github.com/nixos/nixpkgs/compare/32096899af23d49010bd8cf6a91695888d9d9e73...f994293d1eb8812f032e8919e10a594567cf6ef7))__