### PR TITLE
build(deps): bump flake inputs `flake-utils`, `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667077288,
-        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1667351198,
-        "narHash": "sha256-l/0Eor17Hi1hbmZFOm+qlNEiOIBX8AXaWPLZHIXVbI4=",
+        "lastModified": 1667897328,
+        "narHash": "sha256-jwdTgwWUUraNQ0UC735EhRTQqN2kdlZfrfyE+QAQP98=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "44b88d8c310e778c55ef1f7a270d2651266054ca",
+        "rev": "fae754073289566051433fae74ec65783f9e7a6a",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667231093,
-        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
+        "lastModified": 1667811565,
+        "narHash": "sha256-HYml7RdQPQ7X13VNe2CoDMqmifsXbt4ACTKxHRKQE3Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "rev": "667e5581d16745bcda791300ae7e2d73f49fff25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils:__ 
  `github:numtide/flake-utils/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817` →
  `github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f`
  __([view changes](https://github.com/numtide/flake-utils/compare/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817...5aed5285a952e0b949eb3ba02c12fa4fcfef535f))__
* __neovim-upstream:__ 
  `github:neovim/neovim/44b88d8c310e778c55ef1f7a270d2651266054ca` →
  `github:neovim/neovim/fae754073289566051433fae74ec65783f9e7a6a`
  __([view changes](https://github.com/neovim/neovim/compare/44b88d8c310e778c55ef1f7a270d2651266054ca...fae754073289566051433fae74ec65783f9e7a6a))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/d40fea9aeb8840fea0d377baa4b38e39b9582458` →
  `github:nixos/nixpkgs/667e5581d16745bcda791300ae7e2d73f49fff25`
  __([view changes](https://github.com/nixos/nixpkgs/compare/d40fea9aeb8840fea0d377baa4b38e39b9582458...667e5581d16745bcda791300ae7e2d73f49fff25))__