### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1667897328,
-        "narHash": "sha256-jwdTgwWUUraNQ0UC735EhRTQqN2kdlZfrfyE+QAQP98=",
+        "lastModified": 1668547662,
+        "narHash": "sha256-iA72uzTuW6Ggs28FedjUPcqQD6bLnwLWwIkfbTh3s5E=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fae754073289566051433fae74ec65783f9e7a6a",
+        "rev": "fa7e1e26019112ff9e2ea42626995f04e2a4e032",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667811565,
-        "narHash": "sha256-HYml7RdQPQ7X13VNe2CoDMqmifsXbt4ACTKxHRKQE3Q=",
+        "lastModified": 1668417584,
+        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "667e5581d16745bcda791300ae7e2d73f49fff25",
+        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/fae754073289566051433fae74ec65783f9e7a6a` →
  `github:neovim/neovim/fa7e1e26019112ff9e2ea42626995f04e2a4e032`
  __([view changes](https://github.com/neovim/neovim/compare/fae754073289566051433fae74ec65783f9e7a6a...fa7e1e26019112ff9e2ea42626995f04e2a4e032))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/667e5581d16745bcda791300ae7e2d73f49fff25` →
  `github:nixos/nixpkgs/013fcdd106823416918004bb684c3c186d3c460f`
  __([view changes](https://github.com/nixos/nixpkgs/compare/667e5581d16745bcda791300ae7e2d73f49fff25...013fcdd106823416918004bb684c3c186d3c460f))__