### PR TITLE
build(deps): bump flake inputs `flake-compat`, `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1668547662,
-        "narHash": "sha256-iA72uzTuW6Ggs28FedjUPcqQD6bLnwLWwIkfbTh3s5E=",
+        "lastModified": 1669176856,
+        "narHash": "sha256-g65XkgvRSX/f00lNVnZUh9HHl/hpr1hNJcrNqV4jE2k=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fa7e1e26019112ff9e2ea42626995f04e2a4e032",
+        "rev": "f1b88ced07a5dcc62cd847cade2ed97e23fffbf9",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668417584,
-        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
+        "lastModified": 1669052418,
+        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
+        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-compat:__ 
  `github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8` →
  `github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1`
  __([view changes](https://github.com/edolstra/flake-compat/compare/b4a34015c698c7793d592d66adbab377907a2be8...009399224d5e398d03b22badca40a37ac85412a1))__
* __neovim-upstream:__ 
  `github:neovim/neovim/fa7e1e26019112ff9e2ea42626995f04e2a4e032` →
  `github:neovim/neovim/f1b88ced07a5dcc62cd847cade2ed97e23fffbf9`
  __([view changes](https://github.com/neovim/neovim/compare/fa7e1e26019112ff9e2ea42626995f04e2a4e032...f1b88ced07a5dcc62cd847cade2ed97e23fffbf9))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/013fcdd106823416918004bb684c3c186d3c460f` →
  `github:nixos/nixpkgs/20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8`
  __([view changes](https://github.com/nixos/nixpkgs/compare/013fcdd106823416918004bb684c3c186d3c460f...20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8))__