### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1669176856,
-        "narHash": "sha256-g65XkgvRSX/f00lNVnZUh9HHl/hpr1hNJcrNqV4jE2k=",
+        "lastModified": 1669780050,
+        "narHash": "sha256-yHSfl1xWEx/RaHDAXpePDe7G51i3pXaX/AV+zgnNaRk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f1b88ced07a5dcc62cd847cade2ed97e23fffbf9",
+        "rev": "c0d17cec0b691488dbb3a57433e39d97aff36c47",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669052418,
-        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
+        "lastModified": 1669542132,
+        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
+        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/f1b88ced07a5dcc62cd847cade2ed97e23fffbf9` →
  `github:neovim/neovim/c0d17cec0b691488dbb3a57433e39d97aff36c47`
  __([view changes](https://github.com/neovim/neovim/compare/f1b88ced07a5dcc62cd847cade2ed97e23fffbf9...c0d17cec0b691488dbb3a57433e39d97aff36c47))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8` →
  `github:nixos/nixpkgs/a115bb9bd56831941be3776c8a94005867f316a7`
  __([view changes](https://github.com/nixos/nixpkgs/compare/20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8...a115bb9bd56831941be3776c8a94005867f316a7))__