### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1669780050,
-        "narHash": "sha256-yHSfl1xWEx/RaHDAXpePDe7G51i3pXaX/AV+zgnNaRk=",
+        "lastModified": 1670395896,
+        "narHash": "sha256-Nz4ZCPER+Z1JGMf5XDJAcssr/wg6h7PASwy6baym8kY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "c0d17cec0b691488dbb3a57433e39d97aff36c47",
+        "rev": "0caae2376e6c8f6665143e77e4e7a0cdf2b054c4",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1670242877,
+        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/c0d17cec0b691488dbb3a57433e39d97aff36c47` →
  `github:neovim/neovim/0caae2376e6c8f6665143e77e4e7a0cdf2b054c4`
  __([view changes](https://github.com/neovim/neovim/compare/c0d17cec0b691488dbb3a57433e39d97aff36c47...0caae2376e6c8f6665143e77e4e7a0cdf2b054c4))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/a115bb9bd56831941be3776c8a94005867f316a7` →
  `github:nixos/nixpkgs/6e51c97f1c849efdfd4f3b78a4870e6aa2da4198`
  __([view changes](https://github.com/nixos/nixpkgs/compare/a115bb9bd56831941be3776c8a94005867f316a7...6e51c97f1c849efdfd4f3b78a4870e6aa2da4198))__