### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1670395896,
-        "narHash": "sha256-Nz4ZCPER+Z1JGMf5XDJAcssr/wg6h7PASwy6baym8kY=",
+        "lastModified": 1670942634,
+        "narHash": "sha256-d/K7M1InZQy6ea0GgiuUnPmNQgBlKPPDVlZTC9umHFI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "0caae2376e6c8f6665143e77e4e7a0cdf2b054c4",
+        "rev": "090048bec9f80c46a6ce6ff05a419b15bc4bf028",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670242877,
-        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
+        "lastModified": 1670929434,
+        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/0caae2376e6c8f6665143e77e4e7a0cdf2b054c4` →
  `github:neovim/neovim/090048bec9f80c46a6ce6ff05a419b15bc4bf028`
  __([view changes](https://github.com/neovim/neovim/compare/0caae2376e6c8f6665143e77e4e7a0cdf2b054c4...090048bec9f80c46a6ce6ff05a419b15bc4bf028))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/6e51c97f1c849efdfd4f3b78a4870e6aa2da4198` →
  `github:nixos/nixpkgs/1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a`
  __([view changes](https://github.com/nixos/nixpkgs/compare/6e51c97f1c849efdfd4f3b78a4870e6aa2da4198...1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a))__