### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1670942634,
-        "narHash": "sha256-d/K7M1InZQy6ea0GgiuUnPmNQgBlKPPDVlZTC9umHFI=",
+        "lastModified": 1671571217,
+        "narHash": "sha256-2/0pGo8BKkn39dM+1xyvmmgG8nR2lIDfSb0KKfgPulI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "090048bec9f80c46a6ce6ff05a419b15bc4bf028",
+        "rev": "a6747545be8371e53f16189219ec3950d4b219f7",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670929434,
-        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
+        "lastModified": 1671359686,
+        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
+        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/090048bec9f80c46a6ce6ff05a419b15bc4bf028` →
  `github:neovim/neovim/a6747545be8371e53f16189219ec3950d4b219f7`
  __([view changes](https://github.com/neovim/neovim/compare/090048bec9f80c46a6ce6ff05a419b15bc4bf028...a6747545be8371e53f16189219ec3950d4b219f7))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a` →
  `github:nixos/nixpkgs/04f574a1c0fde90b51bf68198e2297ca4e7cccf4`
  __([view changes](https://github.com/nixos/nixpkgs/compare/1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a...04f574a1c0fde90b51bf68198e2297ca4e7cccf4))__