### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1671571217,
-        "narHash": "sha256-2/0pGo8BKkn39dM+1xyvmmgG8nR2lIDfSb0KKfgPulI=",
+        "lastModified": 1672193103,
+        "narHash": "sha256-XhQ2Xl1MBjE+Bg0UZXD3pZ+pwEoHtskO2yG8+RfA6UM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a6747545be8371e53f16189219ec3950d4b219f7",
+        "rev": "bf459641a85ff1b4f24196ba6345de7bb8159884",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
+        "lastModified": 1671983799,
+        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
+        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/a6747545be8371e53f16189219ec3950d4b219f7` →
  `github:neovim/neovim/bf459641a85ff1b4f24196ba6345de7bb8159884`
  __([view changes](https://github.com/neovim/neovim/compare/a6747545be8371e53f16189219ec3950d4b219f7...bf459641a85ff1b4f24196ba6345de7bb8159884))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/04f574a1c0fde90b51bf68198e2297ca4e7cccf4` →
  `github:nixos/nixpkgs/fad51abd42ca17a60fc1d4cb9382e2d79ae31836`
  __([view changes](https://github.com/nixos/nixpkgs/compare/04f574a1c0fde90b51bf68198e2297ca4e7cccf4...fad51abd42ca17a60fc1d4cb9382e2d79ae31836))__