### PR TITLE
build(deps): bump flake inputs `neovim-upstream`, `nixpkgs`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1672193103,
-        "narHash": "sha256-XhQ2Xl1MBjE+Bg0UZXD3pZ+pwEoHtskO2yG8+RfA6UM=",
+        "lastModified": 1672792760,
+        "narHash": "sha256-gjmp7L8hVdguIXY7z8aQoJUeG9cklL28sjoBl9O0dMU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "bf459641a85ff1b4f24196ba6345de7bb8159884",
+        "rev": "ef18c9f9b05caf1f39ed32762f53802e378f143b",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671983799,
-        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "lastModified": 1672617983,
+        "narHash": "sha256-68WDiCBs631mbDDk4UAKdGURKcsfW6hjb7wgudTAe5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __neovim-upstream:__ 
  `github:neovim/neovim/bf459641a85ff1b4f24196ba6345de7bb8159884` →
  `github:neovim/neovim/ef18c9f9b05caf1f39ed32762f53802e378f143b`
  __([view changes](https://github.com/neovim/neovim/compare/bf459641a85ff1b4f24196ba6345de7bb8159884...ef18c9f9b05caf1f39ed32762f53802e378f143b))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/fad51abd42ca17a60fc1d4cb9382e2d79ae31836` →
  `github:nixos/nixpkgs/0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4`
  __([view changes](https://github.com/nixos/nixpkgs/compare/fad51abd42ca17a60fc1d4cb9382e2d79ae31836...0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4))__