### PR TITLE
build(deps): bump flake inputs `flake-parts`, `home-manager`, `nix-darwin`, `nixpkgs`, `nixpkgs-lib`, `nixvim`, `devshell`, `flake-utils_2`, `systems_2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,27 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708939976,
+        "narHash": "sha256-O5+nFozxz2Vubpdl1YZtPrilcIXPcRAjqNdNE8oCRoA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "5ddecd67edbd568ebe0a55905273e56cc82aabe3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -21,11 +43,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -37,6 +59,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -81,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708988456,
-        "narHash": "sha256-RCz7Xe64tN2zgWk+MVHkzg224znwqknJ1RnB7rVqUWw=",
+        "lastModified": 1709578243,
+        "narHash": "sha256-hF96D+c2PBmAFhymMw3z8hou++lqKtZ7IzpFbYeL1/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
+        "rev": "23ff9821bcaec12981e32049e8687f25f11e5ef3",
         "type": "github"
       },
       "original": {
@@ -102,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709001452,
-        "narHash": "sha256-FnZ54wkil54hKvr1irdKic1TE27lHQI9dKQmOJRrtlU=",
+        "lastModified": 1709554374,
+        "narHash": "sha256-1yYgwxBzia+QrOaQaZ6YKqGFfiQcSBwYLzd9XRsRLQY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6c06334f0843c7300d1678726bb607ce526f6b36",
+        "rev": "daa03606dfb5296a22e842acb02b46c1c4e9f5e7",
         "type": "github"
       },
       "original": {
@@ -117,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708984720,
-        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
         "type": "github"
       },
       "original": {
@@ -134,11 +174,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {
@@ -151,6 +191,7 @@
     },
     "nixvim": {
       "inputs": {
+        "devshell": "devshell",
         "flake-compat": [
           "flake-compat"
         ],
@@ -167,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709155917,
-        "narHash": "sha256-S4yHqDKFmJpFQExP7bkOSw+RQaSr8pdOrfSFCOv3G70=",
+        "lastModified": 1709707473,
+        "narHash": "sha256-Jd/1lBwjTOmkVeNAwIn6JrS26OsPj37qOKTV0HHW5bg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "be87309e0c1da19d99d969625300aaed36ff1b91",
+        "rev": "1cda3f6df590ffb5719294311748ab686ce66f69",
         "type": "github"
       },
       "original": {
@@ -185,7 +226,7 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -218,6 +259,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
## Updated Inputs

* __flake-parts:__ 
  `github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f` →
  `github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2`
  __([view changes](https://github.com/hercules-ci/flake-parts/compare/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f...f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2))__
* __home-manager:__ 
  `github:nix-community/home-manager/1d085ea4444d26aa52297758b333b449b2aa6fca` →
  `github:nix-community/home-manager/23ff9821bcaec12981e32049e8687f25f11e5ef3`
  __([view changes](https://github.com/nix-community/home-manager/compare/1d085ea4444d26aa52297758b333b449b2aa6fca...23ff9821bcaec12981e32049e8687f25f11e5ef3))__
* __nix-darwin:__ 
  `github:lnl7/nix-darwin/6c06334f0843c7300d1678726bb607ce526f6b36` →
  `github:lnl7/nix-darwin/daa03606dfb5296a22e842acb02b46c1c4e9f5e7`
  __([view changes](https://github.com/lnl7/nix-darwin/compare/6c06334f0843c7300d1678726bb607ce526f6b36...daa03606dfb5296a22e842acb02b46c1c4e9f5e7))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/13aff9b34cc32e59d35c62ac9356e4a41198a538` →
  `github:nixos/nixpkgs/b8697e57f10292a6165a20f03d2f42920dfaf973`
  __([view changes](https://github.com/nixos/nixpkgs/compare/13aff9b34cc32e59d35c62ac9356e4a41198a538...b8697e57f10292a6165a20f03d2f42920dfaf973))__
* __nixpkgs-lib:__ 
  `github:NixOS/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652` →
  `github:NixOS/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8`
  __([view changes](https://github.com/NixOS/nixpkgs/compare/97b17f32362e475016f942bbdfda4a4a72a8a652...1536926ef5621b09bba54035ae2bb6d806d72ac8))__
* __nixvim:__ 
  `github:nix-community/nixvim/be87309e0c1da19d99d969625300aaed36ff1b91` →
  `github:nix-community/nixvim/1cda3f6df590ffb5719294311748ab686ce66f69`
  __([view changes](https://github.com/nix-community/nixvim/compare/be87309e0c1da19d99d969625300aaed36ff1b91...1cda3f6df590ffb5719294311748ab686ce66f69))__

## Added Inputs

* __devshell:__ `github:numtide/devshell/5ddecd67edbd568ebe0a55905273e56cc82aabe3`
* __flake-utils_2:__ `github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725`
* __systems_2:__ `github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e`