### PR TITLE
build(deps): bump flake inputs `devshell`, `home-manager`, `nix-darwin`, `nixpkgs`, `nixvim`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708939976,
-        "narHash": "sha256-O5+nFozxz2Vubpdl1YZtPrilcIXPcRAjqNdNE8oCRoA=",
+        "lastModified": 1710156081,
+        "narHash": "sha256-4PMY6aumJi5dLFjBzF5O4flKXmadMNq3AGUHKYfchh0=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "5ddecd67edbd568ebe0a55905273e56cc82aabe3",
+        "rev": "bc68b058dc7e6d4d6befc4ec6c60082b6e844b7d",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709578243,
-        "narHash": "sha256-hF96D+c2PBmAFhymMw3z8hou++lqKtZ7IzpFbYeL1/Y=",
+        "lastModified": 1710062421,
+        "narHash": "sha256-FiCNRfyUgJOLYIokLiFsfI7B+Zn9HDnOzFR3uVr5qsQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "23ff9821bcaec12981e32049e8687f25f11e5ef3",
+        "rev": "36f873dfc8e2b6b89936ff3e2b74803d50447e0a",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709554374,
-        "narHash": "sha256-1yYgwxBzia+QrOaQaZ6YKqGFfiQcSBwYLzd9XRsRLQY=",
+        "lastModified": 1709771483,
+        "narHash": "sha256-Hjzu9nCknHLQvhdaRFfCEprH0o15KcaNu1QDr3J88DI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "daa03606dfb5296a22e842acb02b46c1c4e9f5e7",
+        "rev": "550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709479366,
-        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "lastModified": 1709961763,
+        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709707473,
-        "narHash": "sha256-Jd/1lBwjTOmkVeNAwIn6JrS26OsPj37qOKTV0HHW5bg=",
+        "lastModified": 1710283972,
+        "narHash": "sha256-kkN0CJwykU4XoTDLHG68eEBXyp+GLTp7eJGDVrI7QIU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1cda3f6df590ffb5719294311748ab686ce66f69",
+        "rev": "c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __devshell:__ 
  `github:numtide/devshell/5ddecd67edbd568ebe0a55905273e56cc82aabe3` →
  `github:numtide/devshell/bc68b058dc7e6d4d6befc4ec6c60082b6e844b7d`
  __([view changes](https://github.com/numtide/devshell/compare/5ddecd67edbd568ebe0a55905273e56cc82aabe3...bc68b058dc7e6d4d6befc4ec6c60082b6e844b7d))__
* __home-manager:__ 
  `github:nix-community/home-manager/23ff9821bcaec12981e32049e8687f25f11e5ef3` →
  `github:nix-community/home-manager/36f873dfc8e2b6b89936ff3e2b74803d50447e0a`
  __([view changes](https://github.com/nix-community/home-manager/compare/23ff9821bcaec12981e32049e8687f25f11e5ef3...36f873dfc8e2b6b89936ff3e2b74803d50447e0a))__
* __nix-darwin:__ 
  `github:lnl7/nix-darwin/daa03606dfb5296a22e842acb02b46c1c4e9f5e7` →
  `github:lnl7/nix-darwin/550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6`
  __([view changes](https://github.com/lnl7/nix-darwin/compare/daa03606dfb5296a22e842acb02b46c1c4e9f5e7...550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/b8697e57f10292a6165a20f03d2f42920dfaf973` →
  `github:nixos/nixpkgs/3030f185ba6a4bf4f18b87f345f104e6a6961f34`
  __([view changes](https://github.com/nixos/nixpkgs/compare/b8697e57f10292a6165a20f03d2f42920dfaf973...3030f185ba6a4bf4f18b87f345f104e6a6961f34))__
* __nixvim:__ 
  `github:nix-community/nixvim/1cda3f6df590ffb5719294311748ab686ce66f69` →
  `github:nix-community/nixvim/c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431`
  __([view changes](https://github.com/nix-community/nixvim/compare/1cda3f6df590ffb5719294311748ab686ce66f69...c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431))__