### PR TITLE
build(deps): bump flake inputs `flake-utils_2`, `gitignore`, `home-manager`, `nix-darwin`, `nixpkgs`, `nixvim`, `pre-commit-hooks`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710062421,
-        "narHash": "sha256-FiCNRfyUgJOLYIokLiFsfI7B+Zn9HDnOzFR3uVr5qsQ=",
+        "lastModified": 1710714957,
+        "narHash": "sha256-eZCxuF58YWgaJMMRrn8oRkwRhxooe5kBS/s2wRVr9PA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36f873dfc8e2b6b89936ff3e2b74803d50447e0a",
+        "rev": "7b3fca5adcf6c709874a8f2e0c364fe9c58db989",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709771483,
-        "narHash": "sha256-Hjzu9nCknHLQvhdaRFfCEprH0o15KcaNu1QDr3J88DI=",
+        "lastModified": 1710717205,
+        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6",
+        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710283972,
-        "narHash": "sha256-kkN0CJwykU4XoTDLHG68eEBXyp+GLTp7eJGDVrI7QIU=",
+        "lastModified": 1710856562,
+        "narHash": "sha256-JM24d2f60/9q7D7nzyhGm0gcH+HQsrY8Q0rGOFcJzeQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431",
+        "rev": "0a5e0c68b829f9fec135f479e3ec34332660f93d",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1710903454,
+        "narHash": "sha256-PpkuGiqhkR6BlvDCPzUEqJk2kbxsyfcUJHBh7+diPQM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "61846354dc7e593dc4d74700ec51d0613e11b183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-utils_2:__ 
  `github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725` →
  `github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a`
  __([view changes](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a))__
* __gitignore:__ 
  `github:hercules-ci/gitignore.nix/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5` →
  `github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394`
  __([view changes](https://github.com/hercules-ci/gitignore.nix/compare/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5...637db329424fd7e46cf4185293b9cc8c88c95394))__
* __home-manager:__ 
  `github:nix-community/home-manager/36f873dfc8e2b6b89936ff3e2b74803d50447e0a` →
  `github:nix-community/home-manager/7b3fca5adcf6c709874a8f2e0c364fe9c58db989`
  __([view changes](https://github.com/nix-community/home-manager/compare/36f873dfc8e2b6b89936ff3e2b74803d50447e0a...7b3fca5adcf6c709874a8f2e0c364fe9c58db989))__
* __nix-darwin:__ 
  `github:lnl7/nix-darwin/550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6` →
  `github:lnl7/nix-darwin/bcc8afd06e237df060c85bad6af7128e05fd61a3`
  __([view changes](https://github.com/lnl7/nix-darwin/compare/550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6...bcc8afd06e237df060c85bad6af7128e05fd61a3))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/3030f185ba6a4bf4f18b87f345f104e6a6961f34` →
  `github:nixos/nixpkgs/b06025f1533a1e07b6db3e75151caa155d1c7eb3`
  __([view changes](https://github.com/nixos/nixpkgs/compare/3030f185ba6a4bf4f18b87f345f104e6a6961f34...b06025f1533a1e07b6db3e75151caa155d1c7eb3))__
* __nixvim:__ 
  `github:nix-community/nixvim/c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431` →
  `github:nix-community/nixvim/0a5e0c68b829f9fec135f479e3ec34332660f93d`
  __([view changes](https://github.com/nix-community/nixvim/compare/c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431...0a5e0c68b829f9fec135f479e3ec34332660f93d))__
* __pre-commit-hooks:__ 
  `github:cachix/pre-commit-hooks.nix/5df5a70ad7575f6601d91f0efec95dd9bc619431` →
  `github:cachix/pre-commit-hooks.nix/61846354dc7e593dc4d74700ec51d0613e11b183`
  __([view changes](https://github.com/cachix/pre-commit-hooks.nix/compare/5df5a70ad7575f6601d91f0efec95dd9bc619431...61846354dc7e593dc4d74700ec51d0613e11b183))__