### PR TITLE
build(deps): bump flake inputs `home-manager`, `nixpkgs`, `nixvim`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712645849,
-        "narHash": "sha256-67v20E0gH7nvAaMsah2oRIocnxGO25fATUyzQHIywxQ=",
+        "lastModified": 1712989663,
+        "narHash": "sha256-r2X/DIAyKOLiHoncjcxUk1TENWDTTaigRBaY53Cts/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40a99619da804a78a0b166e5c6911108c059c3a8",
+        "rev": "40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712926768,
-        "narHash": "sha256-NQhU4yhHPan0ojwN5nKg2+dJZrxqcv0UkUreQCW2Xjw=",
+        "lastModified": 1713294906,
+        "narHash": "sha256-xJJZdCBzVFpVppaYyUK4lTTNOnbAxrjhodoJL3Oi91E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "38a4fc7709343eb6e15ebb483e141fd95be28122",
+        "rev": "514a51877df9fe41ffc38c5237e3c4e5327e7607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/40a99619da804a78a0b166e5c6911108c059c3a8` →
  `github:nix-community/home-manager/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0`
  __([view changes](https://github.com/nix-community/home-manager/compare/40a99619da804a78a0b166e5c6911108c059c3a8...40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/1042fd8b148a9105f3c0aca3a6177fd1d9360ba5` →
  `github:nixos/nixpkgs/5672bc9dbf9d88246ddab5ac454e82318d094bb8`
  __([view changes](https://github.com/nixos/nixpkgs/compare/1042fd8b148a9105f3c0aca3a6177fd1d9360ba5...5672bc9dbf9d88246ddab5ac454e82318d094bb8))__
* __nixvim:__ 
  `github:nix-community/nixvim/38a4fc7709343eb6e15ebb483e141fd95be28122` →
  `github:nix-community/nixvim/514a51877df9fe41ffc38c5237e3c4e5327e7607`
  __([view changes](https://github.com/nix-community/nixvim/compare/38a4fc7709343eb6e15ebb483e141fd95be28122...514a51877df9fe41ffc38c5237e3c4e5327e7607))__