### PR TITLE
build(deps): bump flake inputs `home-manager`, `nix-darwin`, `nixpkgs`, `nixvim`, `pre-commit-hooks`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713732794,
-        "narHash": "sha256-AYCofb8Zu4Mbc1lHDtju/uxeARawRijmOueAqEMEfMU=",
+        "lastModified": 1714343445,
+        "narHash": "sha256-OzD1P0o46uD3Ix4ZI/g9z3YAeg+4g+W3qctB6bNOReo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "670d9ecc3e46a6e3265c203c2d136031a3d3548e",
+        "rev": "9fe79591c1005ce6f93084ae7f7dab0a2891440d",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713543876,
-        "narHash": "sha256-olEWxacm1xZhAtpq+ZkEyQgR4zgfE7ddpNtZNvubi3g=",
+        "lastModified": 1713946171,
+        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "9e7c20ffd056e406ddd0276ee9d89f09c5e5f4ed",
+        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713714899,
-        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713939051,
-        "narHash": "sha256-EwDbsFjpXANXd2MIvRm4Bz2CDNWIhlV/659xOAxhEv0=",
+        "lastModified": 1714494971,
+        "narHash": "sha256-7RsTiRKMMrlwuert1QNFvnoPIwl1q1cepR4H8jv2iok=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f2f97d844bb39559f3356e209b49c92900d860b8",
+        "rev": "2483dff03dd326296278213a8e051d375b56d3df",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713775815,
-        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
+        "lastModified": 1714478972,
+        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
+        "rev": "2849da033884f54822af194400f8dff435ada242",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __home-manager:__ 
  `github:nix-community/home-manager/670d9ecc3e46a6e3265c203c2d136031a3d3548e` →
  `github:nix-community/home-manager/9fe79591c1005ce6f93084ae7f7dab0a2891440d`
  __([view changes](https://github.com/nix-community/home-manager/compare/670d9ecc3e46a6e3265c203c2d136031a3d3548e...9fe79591c1005ce6f93084ae7f7dab0a2891440d))__
* __nix-darwin:__ 
  `github:lnl7/nix-darwin/9e7c20ffd056e406ddd0276ee9d89f09c5e5f4ed` →
  `github:lnl7/nix-darwin/230a197063de9287128e2c68a7a4b0cd7d0b50a7`
  __([view changes](https://github.com/lnl7/nix-darwin/compare/9e7c20ffd056e406ddd0276ee9d89f09c5e5f4ed...230a197063de9287128e2c68a7a4b0cd7d0b50a7))__
* __nixpkgs:__ 
  `github:nixos/nixpkgs/6143fc5eeb9c4f00163267708e26191d1e918932` →
  `github:nixos/nixpkgs/58a1abdbae3217ca6b702f03d3b35125d88a2994`
  __([view changes](https://github.com/nixos/nixpkgs/compare/6143fc5eeb9c4f00163267708e26191d1e918932...58a1abdbae3217ca6b702f03d3b35125d88a2994))__
* __nixvim:__ 
  `github:nix-community/nixvim/f2f97d844bb39559f3356e209b49c92900d860b8` →
  `github:nix-community/nixvim/2483dff03dd326296278213a8e051d375b56d3df`
  __([view changes](https://github.com/nix-community/nixvim/compare/f2f97d844bb39559f3356e209b49c92900d860b8...2483dff03dd326296278213a8e051d375b56d3df))__
* __pre-commit-hooks:__ 
  `github:cachix/pre-commit-hooks.nix/2ac4dcbf55ed43f3be0bae15e181f08a57af24a4` →
  `github:cachix/pre-commit-hooks.nix/2849da033884f54822af194400f8dff435ada242`
  __([view changes](https://github.com/cachix/pre-commit-hooks.nix/compare/2ac4dcbf55ed43f3be0bae15e181f08a57af24a4...2849da033884f54822af194400f8dff435ada242))__