### PR TITLE
build(deps): bump flake inputs `flake-parts`, `nixpkgs-lib`, `nixvim`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: "Update flake.lock"
-        uses: jessestricker/nix-flake-update@v1
+        uses: DeterminateSystems/update-flake-lock@main
         id: nix-update
 
       - name: "Create pull request"

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714606777,
+        "narHash": "sha256-bMkNmAXLj8iyTvxaaD/StcLSadbj1chPcJOjtuVnLmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "4d34ce6412bc450b1d4208c953dc97c7fc764f1a",
         "type": "github"
       },
       "original": {
@@ -174,11 +174,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714494971,
-        "narHash": "sha256-7RsTiRKMMrlwuert1QNFvnoPIwl1q1cepR4H8jv2iok=",
+        "lastModified": 1714600955,
+        "narHash": "sha256-AHz9OVQeVlbhTboR5Wchjet9a2h+a8aPTDjEyVQLz/g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2483dff03dd326296278213a8e051d375b56d3df",
+        "rev": "82a19581defe682ff9ca7cb8b1b980b6dc297cf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Updated Inputs

* __flake-parts:__ 
  `github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d` →
  `github:hercules-ci/flake-parts/4d34ce6412bc450b1d4208c953dc97c7fc764f1a`
  __([view changes](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...4d34ce6412bc450b1d4208c953dc97c7fc764f1a))__
* __nixpkgs-lib:__ 
  `github:NixOS/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089` →
  `github:NixOS/nixpkgs/58a1abdbae3217ca6b702f03d3b35125d88a2994`
  __([view changes](https://github.com/NixOS/nixpkgs/compare/d8fe5e6c92d0d190646fb9f1056741a229980089...58a1abdbae3217ca6b702f03d3b35125d88a2994))__
* __nixvim:__ 
  `github:nix-community/nixvim/2483dff03dd326296278213a8e051d375b56d3df` →
  `github:nix-community/nixvim/82a19581defe682ff9ca7cb8b1b980b6dc297cf2`
  __([view changes](https://github.com/nix-community/nixvim/compare/2483dff03dd326296278213a8e051d375b56d3df...82a19581defe682ff9ca7cb8b1b980b6dc297cf2))__